### PR TITLE
Fix: Use ${node_bin} for the node binary

### DIFF
--- a/LSP-stylelint.sublime-settings
+++ b/LSP-stylelint.sublime-settings
@@ -1,4 +1,5 @@
 {
+	"command": ["${node_bin}", "${server_path}", "--stdio"],
 	"languages": [
 		{
 			"languageId": "scss",

--- a/plugin.py
+++ b/plugin.py
@@ -14,7 +14,3 @@ class LspStylelintPlugin(NpmClientHandler):
     package_name = __package__
     server_directory = 'language-server'
     server_binary_path = os.path.join(server_directory, 'server.js')
-
-    @classmethod
-    def install_in_cache(cls) -> bool:
-        return False


### PR DESCRIPTION
With the latest version of lsp_utils a change was introduced [1] that allows using a locally
managed node runtime instead of the system one. For that to work, the "node" command
needs to use a variable.

[1] https://github.com/sublimelsp/lsp_utils/commit/403345a0c5c15e84802c712044c630a9fb236b9d